### PR TITLE
Remove infinitely waiting loop

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,7 +13,7 @@ az config set extension.use_dynamic_install=yes_without_prompt
 az login --service-principal -u $CLIENT_ID -p $CLIENT_SECRET --tenant $TENANT_ID
 
 echo Opening tunnel
-az network bastion tunnel --port 50022 --resource-port 22 --target-resource-id $RESOURCE_ID --name $BASTION_NAME --resource-group $RESOURCE_GROUP
+az network bastion tunnel --port 50022 --resource-port 22 --target-resource-id $RESOURCE_ID --name $BASTION_NAME --resource-group $RESOURCE_GROUP &
 
 echo Wait for bastion tunnel port to open
 sleep 60

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,14 +13,20 @@ az config set extension.use_dynamic_install=yes_without_prompt
 az login --service-principal -u $CLIENT_ID -p $CLIENT_SECRET --tenant $TENANT_ID
 
 echo Opening tunnel
-az network bastion tunnel --port 50022 --resource-port 22 --target-resource-id $RESOURCE_ID --name $BASTION_NAME --resource-group $RESOURCE_GROUP &
+az network bastion tunnel --port 50022 --resource-port 22 --target-resource-id $RESOURCE_ID --name $BASTION_NAME --resource-group $RESOURCE_GROUP
 
 echo Wait for bastion tunnel port to open
+sleep 60
+
 {
-  while ! nc -z localhost 50022; do
-    sleep 1
-  done
-  sleep 1
+  if [ ! nc -z localhost 50022 ] then
+    echo WARNING: Wait time exceeded and connection with bastion not yet established; trying again
+    sleep 60
+  
+    if [ ! nc -z localhost 50022 ] then
+      echo ERROR: Bastion tunnel not available. Continuing anyway...
+    fi
+  fi
 } 2>/dev/null
 
 echo Waiting for created


### PR DESCRIPTION
The deploy action no longer works, it times out after the bastion tunnel is established:

```
Opening tunnel
Wait for bastion tunnel port to open
WARNING: The command requires the extension bastion. It will be installed first.
WARNING: Default enabled including preview versions for extension installation now. Disabled in future release. Use '--allow-preview true' to enable it specifically if needed. Use '--allow-preview false' to install stable version only. 
WARNING: Opening tunnel on port: 50022
WARNING: Tunnel is ready, connect on port 50022
WARNING: Ctrl + C to close
# ... and times out
```

This is an attempt to fix this. However, unfortunately I have no way of testing this locally so this is a bit of a stab in the dark.

# Changes
Instead of waiting infinitely for the connection to be established, time out after 120s.

For testing purposes, don't quit after 120s and only print an error messages.

Perhaps the command used for testing whether the connection is established is not (or no longer) correct. 